### PR TITLE
Remove serialized_attributes check

### DIFF
--- a/lib/stampable.rb
+++ b/lib/stampable.rb
@@ -155,8 +155,7 @@ module Ddb #:nodoc:
           def set_updater_attribute
             return unless self.record_userstamp
             # only set updater if the record is new or has changed
-            # or contains a serialized attribute (in which case the attribute value is always updated)
-            return unless self.new_record? || self.changed? || self.class.serialized_attributes.present?
+            return unless self.new_record? || self.changed?
             if respond_to?(self.updater_attribute.to_sym) && has_stamper?
               self.send("#{self.updater_attribute}=".to_sym, self.class.stamper_class.stamper)
             end


### PR DESCRIPTION
`serialized_attributes` is deprecated in Rails 4.2 and will be removed from rails 5

And such check is unnecessary because when there is any changes in serialized attribute, user is supposed to call `attribute_will_change!`, otherwise the change will not be saved.
