### PR TITLE
Fix build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,24 +7,24 @@ rvm:
   - 2.3.1
   - ruby-head
 env:
-  - "RAILS_VERSION=4.0"
-  - "RAILS_VERSION=4.1"
-  - "RAILS_VERSION=4.2"
-  - "RAILS_VERSION=5.0"
+  - "RAILS_VERSION=4.0.0"
+  - "RAILS_VERSION=4.1.0"
+  - "RAILS_VERSION=4.2.0"
+  - "RAILS_VERSION=5.0.0"
 matrix:
   allow_failures:
     - rvm: ruby-head
   exclude:
     - rvm: 2.0.0
-      env: "RAILS_VERSION=5.0"
+      env: "RAILS_VERSION=5.0.0"
     - rvm: 2.1.9
-      env: "RAILS_VERSION=5.0"
+      env: "RAILS_VERSION=5.0.0"
     - rvm: ruby-head
-      env: "RAILS_VERSION=4.0"
+      env: "RAILS_VERSION=4.0.0"
     - rvm: ruby-head
-      env: "RAILS_VERSION=4.1"
+      env: "RAILS_VERSION=4.1.0"
     - rvm: ruby-head
-      env: "RAILS_VERSION=4.2"
+      env: "RAILS_VERSION=4.2.0"
 
 bundler_args: "--jobs=3 --retry=3"
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ matrix:
   exclude:
     - rvm: 2.1.10
       env: "RAILS_VERSION=5.0.0"
+    - rvm: 2.4.0
+      env: "RAILS_VERSION=4.1.0"
+    - rvm: 2.4.0
+      env: "RAILS_VERSION=4.2.0"
     - rvm: ruby-head
       env: "RAILS_VERSION=4.1.0"
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ sudo: false
 language: ruby
 rvm:
   - 2.0.0
-  - 2.1.9
-  - 2.2.5
-  - 2.3.1
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
   - ruby-head
 env:
   - "RAILS_VERSION=4.0.0"
@@ -17,7 +18,7 @@ matrix:
   exclude:
     - rvm: 2.0.0
       env: "RAILS_VERSION=5.0.0"
-    - rvm: 2.1.9
+    - rvm: 2.1.10
       env: "RAILS_VERSION=5.0.0"
     - rvm: ruby-head
       env: "RAILS_VERSION=4.0.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.0.0
   - 2.1.10
   - 2.2.6
   - 2.3.3
   - 2.4.0
   - ruby-head
 env:
-  - "RAILS_VERSION=4.0.0"
   - "RAILS_VERSION=4.1.0"
   - "RAILS_VERSION=4.2.0"
   - "RAILS_VERSION=5.0.0"
@@ -16,12 +14,8 @@ matrix:
   allow_failures:
     - rvm: ruby-head
   exclude:
-    - rvm: 2.0.0
-      env: "RAILS_VERSION=5.0.0"
     - rvm: 2.1.10
       env: "RAILS_VERSION=5.0.0"
-    - rvm: ruby-head
-      env: "RAILS_VERSION=4.0.0"
     - rvm: ruby-head
       env: "RAILS_VERSION=4.1.0"
     - rvm: ruby-head

--- a/activerecord-userstamp.gemspec
+++ b/activerecord-userstamp.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', rails_version
 
-  s.add_development_dependency 'tzinfo-data'
+  s.add_development_dependency 'tzinfo-data' if RUBY_PLATFORM =~ /mswin|mingw/
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'rspec-rails', '>= 3.3'

--- a/activerecord-userstamp.gemspec
+++ b/activerecord-userstamp.gemspec
@@ -23,12 +23,12 @@ Gem::Specification.new do |s|
     rails_version =
       case ENV['RAILS_VERSION']
       when nil, ''
-        '>= 4.0'
+        '>= 4.1'
       else
         "~> #{ENV['RAILS_VERSION']}"
       end
   else
-    rails_version = '>= 4.0'
+    rails_version = '>= 4.1'
   end
 
   s.add_dependency 'rails', rails_version

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -19,8 +19,11 @@ module Dummy
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
-    # Do not swallow errors in after_commit/after_rollback callbacks.
-    config.active_record.raise_in_transactional_callbacks = true
+    # Do not swallow errors in after_commit/after_rollback callbacks. This only applies to Rails 4.2
+    # and is deprecated in Rail 5.
+    if ActiveRecord.version == Gem::Version.new('4.2.x')
+      config.active_record.raise_in_transactional_callbacks = true
+    end
 
     config.after_initialize do
       require_relative '../db/schema'

--- a/spec/lib/stamping_spec.rb
+++ b/spec/lib/stamping_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe 'Stamping', type: :model do
         User.stamper = @hera
         expect(User.stamper).to eq(@hera)
 
-        @delynn.name << " Berry"
+        @delynn.name = @delynn.name + " Berry"
         @delynn.save
         @delynn.reload
         expect(@delynn.creator).to eq(@zeus)
@@ -149,7 +149,7 @@ RSpec.describe 'Stamping', type: :model do
         User.stamper = @hera.id
         expect(User.stamper).to eq(@hera.id)
 
-        @delynn.name << " Berry"
+        @delynn.name = @delynn.name + " Berry"
         @delynn.save
         @delynn.reload
         expect(@delynn.creator_id).to eq(@zeus.id)
@@ -184,7 +184,7 @@ RSpec.describe 'Stamping', type: :model do
         Person.stamper = @nicole.id
         expect(Person.stamper).to eq(@nicole.id)
 
-        @first_post.title << " - Updated"
+        @first_post.title = @first_post.title + " - Updated"
         @first_post.save
         @first_post.reload
         expect(@first_post.creator_id).to eq(@delynn.id)
@@ -199,7 +199,7 @@ RSpec.describe 'Stamping', type: :model do
         Person.stamper = @nicole
         expect(Person.stamper).to eq(@nicole)
 
-        @first_post.title << " - Updated"
+        @first_post.title = @first_post.title + " - Updated"
         @first_post.save
         @first_post.reload
         expect(@first_post.creator_id).to eq(@delynn.id)


### PR DESCRIPTION
This properly ensures that the different Rails versions are tested.

Rails 4.0 and Ruby 2.0 are no longer part of the build matrix because they have been out of support for a long time. The minimum required Rails version is now Rails 4.1.