### PR TITLE
Compatible to rails 5.1.x and make it deleter optional on saving.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - "RAILS_VERSION=4.1.0"
   - "RAILS_VERSION=4.2.0"
   - "RAILS_VERSION=5.0.0"
+  - "RAILS_VERSION=5.1.0"
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/lib/active_record/userstamp/configuration.rb
+++ b/lib/active_record/userstamp/configuration.rb
@@ -46,4 +46,13 @@ module ActiveRecord::Userstamp::Configuration
   #   By default, this is set to +:deleter_id+.
   mattr_accessor :deleter_attribute
   self.deleter_attribute = :deleter_id
+
+  # !@attribute [rw] company_attribute
+  #   Determines the name of the column in the database which stores the name of the company.
+  #
+  #   Override the attribute by using the stampable class method within a model.
+  #
+  #   By default, this is set to +:company_id+.
+  mattr_accessor :company_attribute
+  self.company_attribute = :deleter_id
 end

--- a/lib/active_record/userstamp/stampable.rb
+++ b/lib/active_record/userstamp/stampable.rb
@@ -84,7 +84,7 @@ module ActiveRecord::Userstamp::Stampable
         associations.first
       belongs_to :updater, relation_options.reverse_merge(foreign_key: config.updater_attribute) if
         associations.second
-      belongs_to :deleter, relation_options.reverse_merge(foreign_key: config.deleter_attribute) if
+      belongs_to :deleter, relation_options.reverse_merge(foreign_key: config.deleter_attribute, optional: true) if
         associations.third
     end
   end

--- a/lib/active_record/userstamp/utilities.rb
+++ b/lib/active_record/userstamp/utilities.rb
@@ -33,7 +33,8 @@ module ActiveRecord::Userstamp::Utilities
 
     [config.creator_attribute.present? && columns.include?(config.creator_attribute.to_s),
      config.updater_attribute.present? && columns.include?(config.updater_attribute.to_s),
-     config.deleter_attribute.present? && columns.include?(config.deleter_attribute.to_s)]
+     config.deleter_attribute.present? && columns.include?(config.deleter_attribute.to_s),
+     config.company_attribute.present? && columns.include?(config.company_attribute.to_s),]
   rescue ActiveRecord::StatementInvalid => _
     nil
   end
@@ -54,6 +55,10 @@ module ActiveRecord::Userstamp::Utilities
         association.foreign_key
       end
 
-    record.send("#{attribute}=", stamp_value)
+    if attribute == 'company_id'
+      record.send("#{attribute}=", stamp_value.company_id)
+    else
+      record.send("#{attribute}=", stamp_value)
+    end
   end
 end


### PR DESCRIPTION
For rails 5.1 when using soft deletes, it must be presence when saving new object. This make it deleter_id optional.