### PR TITLE
Prevent setting the creator when updating, even if the previous creator is null

### DIFF
--- a/lib/active_record/userstamp/stampable.rb
+++ b/lib/active_record/userstamp/stampable.rb
@@ -14,7 +14,7 @@ module ActiveRecord::Userstamp::Stampable
     before_validation :set_updater_attribute, if: :record_userstamp
     before_validation :set_creator_attribute, on: :create, if: :record_userstamp
     before_save :set_updater_attribute, if: :record_userstamp
-    before_save :set_creator_attribute, on: :create, if: :record_userstamp
+    before_create :set_creator_attribute, if: :record_userstamp
     before_destroy :set_deleter_attribute, if: :record_userstamp
   end
 

--- a/spec/lib/stamping_spec.rb
+++ b/spec/lib/stamping_spec.rb
@@ -48,6 +48,21 @@ RSpec.describe 'Stamping', type: :model do
           expect(person.creator).to eq(@hera)
           expect(person.updater).to eq(@zeus)
         end
+
+        it 'does not reset the creator when not defined previously' do
+          expect(User.stamper).to eq(@zeus)
+          person = nil
+          Person.without_stamps do
+            person = Person.create(name: 'David', updater_id: @hera.id)
+            expect(person.creator_id).to be_nil
+            expect(person.updater_id).to eq(@hera.id)
+          end
+
+          person.name = 'Julian'
+          person.save!
+          expect(person.creator_id).to be_nil
+        end
+
       end
 
       context 'when saving without validations' do


### PR DESCRIPTION
before_save does not have the on: key